### PR TITLE
Fix media issue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - 3355:3355
     volumes:
-      - ./data/blossom:/haven/blossom
+      - ./data/blossom:/haven/data/blossom
       - ./data/db:/haven/db
       - ./relays_blastr.json:/haven/relays_blastr.json
       - ./relays_import.json:/haven/relays_import.json


### PR DESCRIPTION
Haven uploads media to `/haven/data/blossom` **not** `/haven/blossom`. As a result the binding was just binding to empty directories and thus media uploads were not persistent. You can verify this by checking an existing deployments data directory on the host machine and seeing if any of your uploads appear in the blossom directory - they won't. The new binding ensures persistence.